### PR TITLE
Add minor mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ script:
   - cask build
   - cask clean-elc
   - cask exec ert-runner
-  - cask emacs --batch -l lint-exercism.el
+  - cask emacs --batch -l util/lint-exercism.el

--- a/exercism.el
+++ b/exercism.el
@@ -31,6 +31,11 @@
 ;;; Code:
 (require 'json)
 
+(defgroup exercism nil
+  "Functions for Exercism, a programming learning platform."
+  :prefix "exercism-"
+  :group 'external)
+
 (defcustom exercism-json-file "~/.exercism.json"
   "Filepath to Exercism JSON file."
   :type 'string)
@@ -56,6 +61,12 @@
       (start-process-shell-command process-name
                                    process-buffer
                                    (format "exercism %s" cmd)))))
+
+(define-minor-mode exercism-mode
+  "Minor mode to submit Exercism solutions and fetch problems."
+  :group 'exercism
+  :global nil
+  :lighter " Exercism ")
 
 (provide 'exercism)
 ;;; exercism.el ends here

--- a/exercism.el
+++ b/exercism.el
@@ -76,8 +76,8 @@
   :global nil
   :lighter " Exercism "
   (let ((map exercism-mode-map))
-    (define-key map (kbd "C-c e s") #'exercism-submit-buffer)
-    (define-key map (kbd "C-c e f") #'exercism-fetch)))
+    (define-key map (kbd "C-c [ s") #'exercism-submit-buffer)
+    (define-key map (kbd "C-c [ f") #'exercism-fetch)))
 
 (with-eval-after-load
     (if (file-exists-p exercism-json-file)

--- a/exercism.el
+++ b/exercism.el
@@ -80,10 +80,12 @@
     (define-key map (kbd "C-c e f") #'exercism-fetch)))
 
 (with-eval-after-load
-    (let* ((e-dir-locals (concat (exercism--get-directory) "/" dir-locals-file)))
-      (unless (file-exists-p e-dir-locals)
-        (with-temp-file e-dir-locals
-          (insert "((nil . ((eval . (exercism-mode t)))))")))))
+    (if (file-exists-p exercism-json-file)
+        (let* ((e-dir-locals (concat (exercism--get-directory) "/" dir-locals-file)))
+          (unless (file-exists-p e-dir-locals)
+            (with-temp-file e-dir-locals
+              (insert "((nil . ((eval . (exercism-mode t)))))"))))
+      (message "[exercism] You should run \"exercism configure\" or configure `exercism-json-file'.")))
 
 (provide 'exercism)
 ;;; exercism.el ends here

--- a/exercism.el
+++ b/exercism.el
@@ -40,6 +40,10 @@
   "Filepath to Exercism JSON file."
   :type 'string)
 
+(defvar exercism-mode-map
+  (make-sparse-keymap)
+  "Keymap for `exercism-mode'.")
+
 (defun exercism-submit-buffer ()
   "Submit function `buffer-file-name' result as a solution."
   (interactive)
@@ -70,7 +74,10 @@
   "Minor mode to submit Exercism solutions and fetch problems."
   :group 'exercism
   :global nil
-  :lighter " Exercism ")
+  :lighter " Exercism "
+  (let ((map exercism-mode-map))
+    (define-key map (kbd "C-c e s") #'exercism-submit-buffer)
+    (define-key map (kbd "C-c e f") #'exercism-fetch)))
 
 (with-eval-after-load
     (let* ((e-dir-locals (concat (exercism--get-directory) "/" dir-locals-file)))

--- a/exercism.el
+++ b/exercism.el
@@ -72,5 +72,11 @@
   :global nil
   :lighter " Exercism ")
 
+(with-eval-after-load
+    (let* ((e-dir-locals (concat (exercism--get-directory) "/" dir-locals-file)))
+      (unless (file-exists-p e-dir-locals)
+        (with-temp-file e-dir-locals
+          (insert "((nil . ((eval . (exercism-mode t)))))")))))
+
 (provide 'exercism)
 ;;; exercism.el ends here

--- a/exercism.el
+++ b/exercism.el
@@ -48,7 +48,7 @@
 (defun exercism-fetch ()
   "Fetch a new language problem."
   (interactive)
-  (let* ((exercism-dir (cdr (assoc 'dir (json-read-file exercism-json-file))))
+  (let* ((exercism-dir (exercism--get-directory))
          (lang-list (directory-files exercism-dir nil "[^\.]+$"))
          (lang (completing-read "Fetch for: " lang-list)))
     (exercism--run-command (format "fetch %s" lang))))
@@ -61,6 +61,10 @@
       (start-process-shell-command process-name
                                    process-buffer
                                    (format "exercism %s" cmd)))))
+
+(defun exercism--get-directory ()
+  "Return Exercism directory value from `exercism-json-file'."
+  (expand-file-name (cdr (assoc 'dir (json-read-file exercism-json-file)))))
 
 (define-minor-mode exercism-mode
   "Minor mode to submit Exercism solutions and fetch problems."

--- a/util/lint-exercism.el
+++ b/util/lint-exercism.el
@@ -33,6 +33,7 @@
 (package-initialize)
 (package-refresh-contents)
 
+(require 'cl-lib)
 (require 'checkdoc)
 (require 'package-lint)
 
@@ -49,9 +50,14 @@
     (kill-emacs 1)))
 
 (with-current-buffer (find-file "exercism.el")
-  (when (package-lint-buffer)
-    (exercism-lint-print "*Package-Lint*")
-    (kill-emacs 1)))
+  (let ((lint (package-lint-buffer)))
+    (when lint
+      (dolist (item lint)
+        (let ((line (car item))
+              (type (cl-caddr item))
+              (output (cl-cadddr item)))
+          (message (format "%s:%s: %s" type line output))))
+      (kill-emacs 1))))
 
 (provide 'lint-exercism)
 ;;; lint-exercism.el ends here


### PR DESCRIPTION
Adds a minor mode and enables that minor mode when you visit your Exercism directory, as configured in your `exercism-json-file`. The minor mode gives you two keybindings:

* `C-c [ f` to fetch a new language problem
* `C-c [ s` to submit the current buffer file as a solution